### PR TITLE
Add the ability to  manually trigger container publish

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,7 +1,10 @@
 name: Publish
 
 on:
+  workflow_dispatch:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 


### PR DESCRIPTION
Because unified CI creates draft releases and pushes tags, and the limitation of github actions which actions cannot trigger actions we don't get automatic container publication.

Enable the ability to manually run the action as well as run on merge to main so that we get `latest` tag regardless.