### PR TITLE
Make storage provider id not required

### DIFF
--- a/eventrecorder/event.go
+++ b/eventrecorder/event.go
@@ -57,8 +57,6 @@ func (e Event) Validate() error {
 		return errors.New("property instanceId is required")
 	case e.Cid == "":
 		return errors.New("property cid is required")
-	case e.StorageProviderId == "":
-		return errors.New("property storageProviderId is required")
 	case e.Phase == "":
 		return errors.New("property phase is required")
 	case !validPhase(e.Phase):
@@ -80,8 +78,10 @@ func (e Event) Validate() error {
 		if err != nil {
 			return fmt.Errorf("cid must be valid: %w", err)
 		}
-		if _, err := peer.Decode(e.StorageProviderId); err != nil {
-			return fmt.Errorf("storageProviderId must be valid: %w", err)
+		if e.StorageProviderId != "" {
+			if _, err := peer.Decode(e.StorageProviderId); err != nil {
+				return fmt.Errorf("storageProviderId must be valid: %w", err)
+			}
 		}
 		return nil
 	}

--- a/eventrecorder/recorder_integration_test.go
+++ b/eventrecorder/recorder_integration_test.go
@@ -89,9 +89,31 @@ func TestPostEvent(t *testing.T) {
 
 	var wantEventBatch eventrecorder.EventBatch
 	require.NoError(t, json.Unmarshal(encEventBatch, &wantEventBatch))
-	require.Len(t, wantEventBatch.Events, 1)
+	require.Len(t, wantEventBatch.Events, 2)
 	wantEvent := wantEventBatch.Events[0]
 
+	require.Equal(t, [16]byte(wantEvent.RetrievalId), e.RetrievalId.Bytes)
+	require.Equal(t, wantEvent.InstanceId, e.InstanceId)
+	require.Equal(t, wantEvent.Cid, e.Cid)
+	require.Equal(t, wantEvent.StorageProviderId, e.StorageProviderId)
+	require.Equal(t, wantEvent.Phase, e.Phase)
+	require.Equal(t, wantEvent.PhaseStartTime.UnixMicro(), e.PhaseStartTime.UnixMicro())
+	require.Equal(t, wantEvent.EventName, e.EventName)
+	require.Equal(t, wantEvent.EventTime.UnixMicro(), e.EventTime.UnixMicro())
+
+	require.True(t, rows.Next())
+	require.NoError(t, rows.Scan(
+		&e.RetrievalId,
+		&e.InstanceId,
+		&e.Cid,
+		&e.StorageProviderId,
+		&e.Phase,
+		&e.PhaseStartTime,
+		&e.EventName,
+		&e.EventTime,
+	))
+
+	wantEvent = wantEventBatch.Events[1]
 	require.Equal(t, [16]byte(wantEvent.RetrievalId), e.RetrievalId.Bytes)
 	require.Equal(t, wantEvent.InstanceId, e.InstanceId)
 	require.Equal(t, wantEvent.Cid, e.Cid)

--- a/testdata/good.json
+++ b/testdata/good.json
@@ -9,6 +9,16 @@
       "phaseStartTime": "2023-03-02T00:15:50.479910907Z",
       "eventName": "started",
       "eventTime": "2023-03-02T00:15:52.361371026Z"
+    },
+    {
+      "retrievalId": "d05a522e-9608-401a-a33f-1eb4ac4111a0",
+      "instanceId": "test-instance-id",
+      "cid": "bafybeic4jpi2detp5n3q6rjo7ckulebtr7dsvt2tbrtcqlnnzqmi3bzz2y",
+      "storageProviderId": "",
+      "phase": "indexer",
+      "phaseStartTime": "2023-03-02T00:15:50.479910907Z",
+      "eventName": "started",
+      "eventTime": "2023-03-02T00:15:52.361371026Z"
     }
   ]
 }

--- a/testdata/invalid-providerid.json
+++ b/testdata/invalid-providerid.json
@@ -3,8 +3,8 @@
     {
       "retrievalId": "d05a522e-9608-401a-a33f-1eb4ac4111a0",
       "instanceId": "test-instance-id",
-      "cid": "fish",
-      "storageProviderId": "12D3KooWHwRmkj4Jxfo2YnKJC4YBzTNEGDW6Et4E68r7RYVXk46h",
+      "cid": "bafybeic4jpi2detp5n3q6rjo7ckulebtr7dsvt2tbrtcqlnnzqmi3bzz2y",
+      "storageProviderId": "fish",
       "phase": "query",
       "phaseStartTime": "2023-03-02T00:15:50.479910907Z",
       "eventName": "started",


### PR DESCRIPTION
# Goals

I'm getting bad request on a bunch of my posts to the current event recorder. I'm pretty sure it's cause we're requiring storage provider id, which can and should be blank for indexer events as well as bitswap retrieval.

# Implementation

- make SP id not required
- add integration test to verify behavior.