### PR TITLE
More informative error message

### DIFF
--- a/eventrecorder/recorder.go
+++ b/eventrecorder/recorder.go
@@ -97,7 +97,7 @@ func (r *EventRecorder) handleRetrievalEvents(res http.ResponseWriter, req *http
 	// Validate JSON
 	if err := batch.Validate(); err != nil {
 		http.Error(res, err.Error(), http.StatusBadRequest)
-		logger.Warn("Rejected bad request with invalid event")
+		logger.Warnf("Rejected bad request with invalid event: %s", err.Error())
 		return
 	}
 


### PR DESCRIPTION
# Goals

It would be helpful to see in logs why an event does not get written -- I'm still seeing Bad Request in the logs but don't know why.

# Implementation

-- add the error reason to the log warning that's generated when an event does not save.