### PR TITLE
Add endpoint to run the common query used to gather metrics and wipe the db

### DIFF
--- a/eventrecorder/recorder.go
+++ b/eventrecorder/recorder.go
@@ -66,6 +66,7 @@ func (r *EventRecorder) httpServerMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/retrieval-events", r.handleRetrievalEvents)
 	mux.HandleFunc("/ready", r.handleReady)
+	mux.HandleFunc("/v1/summarize-and-clear", r.handleStats)
 	return mux
 }
 
@@ -145,9 +146,88 @@ func (r *EventRecorder) handleRetrievalEvents(res http.ResponseWriter, req *http
 		http.Error(res, "", http.StatusInternalServerError)
 		logger.Errorw("At least one retrieval event insertion failed", "err", err)
 		return
-	} else {
-		logger.Infow("Successfully submitted batch event insertion")
 	}
+	logger.Infow("Successfully submitted batch event insertion")
+}
+
+type EventSummary struct {
+	TotalAttempts              uint64    `json:"totalAttempts"`
+	AttemptedBitswap           uint64    `json:"attemptedBitswap"`
+	AttemptedGraphSync         uint64    `json:"attemptedGraphSync"`
+	AttemptedBoth              uint64    `json:"attemptedBoth"`
+	AttemptedEither            uint64    `json:"attemptedEither"`
+	BitswapSuccesses           uint64    `json:"bitswapSuccesses"`
+	GraphSyncSuccesses         uint64    `json:"graphSyncSuccesses"`
+	AvgBandwidth               *float64  `json:"avgBandwidth"`
+	FirstByte                  []float64 `json:"firstByte"`
+	DownloadSize               []float64 `json:"downloadSize"`
+	GraphsyncAttemptsPastQuery uint64    `json:"graphsyncAttemptsPastQuery"`
+}
+
+func (r *EventRecorder) handleStats(res http.ResponseWriter, req *http.Request) {
+	logger := logger.With("method", req.Method, "path", req.URL.Path)
+	if req.Method != http.MethodGet {
+		res.Header().Add("Allow", http.MethodGet)
+		http.Error(res, "", http.StatusMethodNotAllowed)
+		logger.Warn("Rejected disallowed method")
+		return
+	}
+
+	ctx := req.Context()
+	runQuery := `
+	select count(all_attempts.retrieval_id) as total_attempts, 
+  count(bitswap_retrievals.retrieval_id) as attempted_bitswap, 
+  count(graphsync_retrievals.retrieval_id) as attempted_graphsync, 
+  sum(case when bitswap_retrievals.retrieval_id IS NOT NULL and graphsync_retrievals.retrieval_id IS NOT NULL then 1 else 0 end) as attempted_both,
+  sum(case when bitswap_retrievals.retrieval_id IS NOT NULL or graphsync_retrievals.retrieval_id IS NOT NULL then 1 else 0 end) as attempted_either,
+  sum(case when successful_retrievals.storage_provider_id = 'Bitswap' then 1 else 0 end) as bitswap_successes,
+  sum(case when successful_retrievals.storage_provider_id <> 'Bitswap' and successful_retrievals.retrieval_id IS NOT NULL then 1 else 0 end) as graphsync_successes,
+  case when extract('epoch' from sum(successful_retrievals.event_time - first_byte_retrievals.event_time)) = 0 then 0 else sum(successful_retrievals.received_size)::float / extract('epoch' from sum(successful_retrievals.event_time - first_byte_retrievals.event_time))::float end as avg_bandwidth,
+  percentile_cont('{0.5, 0.9, 0.95}'::double precision[]) WITHIN GROUP (ORDER BY (extract ('epoch' from first_byte_retrievals.event_time - all_attempts.event_time))) as p50_p90_p95_first_byte,
+  percentile_cont('{0.5, 0.9, 0.95}'::double precision[]) WITHIN GROUP (ORDER BY (successful_retrievals.received_size)) as p50_p90_p95_download_size,
+	count(graphsync_retrieval_attempts.retrieval_id) as graphsync_retrieval_attempts_past_query
+  from (
+    select distinct on (retrieval_id) retrieval_id, event_time from retrieval_events order by retrieval_id, event_time
+    ) as all_attempts left join (
+      select distinct retrieval_id from retrieval_events where storage_provider_id = 'Bitswap'
+      ) as bitswap_retrievals on all_attempts.retrieval_id = bitswap_retrievals.retrieval_id left join (
+        select distinct retrieval_id from retrieval_events where storage_provider_id <> 'Bitswap' and phase <> 'indexer'
+        ) as graphsync_retrievals on graphsync_retrievals.retrieval_id = all_attempts.retrieval_id left join (
+          select distinct on (retrieval_id) retrieval_id, event_time, storage_provider_id, (event_details ->	'receivedSize')::int8 as received_size from retrieval_events where event_name = 'success' order by retrieval_id, event_time
+        ) as successful_retrievals on  successful_retrievals.retrieval_id = all_attempts.retrieval_id left join (
+          select retrieval_id, event_time, storage_provider_id from retrieval_events where event_name = 'first-byte-received'
+        ) as first_byte_retrievals on successful_retrievals.retrieval_id = first_byte_retrievals.retrieval_id and successful_retrievals.storage_provider_id = first_byte_retrievals.storage_provider_id left join (
+					select distinct retrieval_id from retrieval_events where storage_provider_id <> 'Bitswap' and phase = 'retrieval'
+        ) as graphsync_retrieval_attempts on graphsync_retrievals.retrieval_id = graphsync_retrieval_attempts.retrieval_id
+	`
+
+	row := r.db.QueryRow(ctx, runQuery)
+	var summary EventSummary
+	err := row.Scan(&summary.TotalAttempts,
+		&summary.AttemptedBitswap,
+		&summary.AttemptedGraphSync,
+		&summary.AttemptedBoth,
+		&summary.AttemptedEither,
+		&summary.BitswapSuccesses,
+		&summary.GraphSyncSuccesses,
+		&summary.AvgBandwidth,
+		&summary.FirstByte,
+		&summary.DownloadSize,
+		&summary.GraphsyncAttemptsPastQuery)
+	if err != nil {
+		http.Error(res, err.Error(), http.StatusInternalServerError)
+		logger.Errorw("Failure to execute query", "err", err)
+		return
+	}
+	err = json.NewEncoder(res).Encode(summary)
+	if err != nil {
+		http.Error(res, err.Error(), http.StatusInternalServerError)
+		logger.Errorw("failed encoding result", "err", err)
+		return
+	}
+
+	r.db.Exec(ctx, "TRUNCATE TABLE retrieval_events")
+	logger.Infow("Successfully ran summary and cleared DB")
 }
 
 func (r *EventRecorder) handleReady(res http.ResponseWriter, req *http.Request) {

--- a/eventrecorder/recorder_integration_test.go
+++ b/eventrecorder/recorder_integration_test.go
@@ -124,4 +124,19 @@ func TestPostEvent(t *testing.T) {
 	require.Equal(t, wantEvent.EventTime.UnixMicro(), e.EventTime.UnixMicro())
 
 	require.False(t, rows.Next())
+
+	// verify we are able to fetch a summary and decode, and use this to clear the DB
+	resp, err = http.Get("http://localhost:8080/v1/summarize-and-clear")
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, 200)
+
+	var summary eventrecorder.EventSummary
+	err = json.NewDecoder(resp.Body).Decode(&summary)
+	require.NoError(t, err)
+
+	require.Equal(t, summary.TotalAttempts, uint64(1))
+	require.Equal(t, summary.AttemptedBitswap, uint64(0))
+	require.Equal(t, summary.AttemptedGraphSync, uint64(1))
+	require.Equal(t, summary.AttemptedBoth, uint64(0))
+	require.Equal(t, summary.AttemptedEither, uint64(1))
 }


### PR DESCRIPTION
# Goals

This is just to bring us to parity with the existing DB -- giving me the ability to run the query I run to collect metrics, and then wipe the DB afterward. This will change when we start recording aggregated events but it would make my life easier to have this available until then.

I realize exposing a "WIPE" endpoint is a bit risky. Let's not worry too much for now cause this is going to go away hopefully this week.