### PR TITLE
Move query to a seperate command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ RUN go mod download
 
 COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/recorder ./cmd/recorder
+RUN CGO_ENABLED=0 go build -o /go/bin/stats ./cmd/stats
 
 FROM gcr.io/distroless/static-debian11
 COPY --from=build /go/bin/recorder /usr/bin/
+COPY --from=build /go/bin/stats /usr/bin/
 
 ENTRYPOINT ["/usr/bin/recorder"]

--- a/cmd/stats/main.go
+++ b/cmd/stats/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/filecoin-project/lassie-event-recorder/statsrunner"
+	"github.com/ipfs/go-log/v2"
+	"github.com/olekukonko/tablewriter"
+)
+
+var logger = log.Logger("lassie/statsrunner")
+
+func main() {
+	dbDSN := flag.String("dbDSN", "", "The database Data Source Name. Alternatively, it may be specified via LASSIE_EVENT_RECORDER_DB_DSN environment variable. If both are present, the environment variable takes precedence.")
+	logLevel := flag.String("logLevel", "info", "The logging level. Only applied if GOLOG_LOG_LEVEL environment variable is unset.")
+	wipeTable := flag.Bool("wipeTable", false, "tells the command to wipe the table after running the query")
+	flag.Parse()
+
+	if _, set := os.LookupEnv("GOLOG_LOG_LEVEL"); !set {
+		_ = log.SetLogLevel("*", *logLevel)
+	}
+
+	if v, set := os.LookupEnv("LASSIE_EVENT_RECORDER_DB_DSN"); set {
+		dbDSN = &v
+	}
+
+	ctx := context.Background()
+
+	statsRunner, err := statsrunner.New(*dbDSN)
+	if err != nil {
+		logger.Fatalw("error setting up stats runner", "err", err)
+	}
+
+	if err := statsRunner.Start(ctx); err != nil {
+		logger.Fatalw("error starting stats runner", "err", err)
+	}
+
+	summary, err := statsRunner.GetEventSummary(ctx)
+	if err != nil {
+		logger.Fatalw("error running query", "err", err)
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Total Attempts", "Attempted Bitswap", "Attempted GraphSync", "Attempted Both", "Attempted Either", "Bitswap Successes", "GraphSync Successes", "Average Bandwidth", "Time to first byte", "Download Size", "GraphSync Attempts Past Query"})
+	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+	table.SetCenterSeparator("|")
+	table.Append([]string{
+		fmt.Sprintf("%d", summary.TotalAttempts),
+		fmt.Sprintf("%d", summary.AttemptedBitswap),
+		fmt.Sprintf("%d", summary.AttemptedGraphSync),
+		fmt.Sprintf("%d", summary.AttemptedBoth),
+		fmt.Sprintf("%d", summary.AttemptedEither),
+		fmt.Sprintf("%d", summary.BitswapSuccesses),
+		fmt.Sprintf("%d", summary.GraphSyncSuccesses),
+		fmt.Sprintf("%d", summary.AvgBandwidth),
+		fmt.Sprintf("%v", summary.FirstByte),
+		fmt.Sprintf("%v", summary.DownloadSize),
+		fmt.Sprintf("%d", summary.GraphsyncAttemptsPastQuery),
+	}) // Add Bulk Data
+	table.Render()
+
+	if *wipeTable {
+		statsRunner.WipeTable(ctx)
+		logger.Infow("Successfully ran summary and cleared DB")
+	}
+
+	statsRunner.Close()
+
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/stretchr/testify v1.8.2
 )
 
+require github.com/mattn/go-runewidth v0.0.9 // indirect
+
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -65,6 +67,7 @@ require (
 	github.com/multiformats/go-multihash v0.2.1 // indirect
 	github.com/multiformats/go-multistream v0.4.1 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.89.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/miekg/dns v1.1.51 h1:0+Xg7vObnhrz/4ZCZcZh7zPXlmU0aveS2HDBd0m0qSo=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
@@ -293,6 +295,8 @@ github.com/multiformats/go-varint v0.0.5/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXS
 github.com/multiformats/go-varint v0.0.6/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/nEGOHFS8=
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=

--- a/statsrunner/statsrunner.go
+++ b/statsrunner/statsrunner.go
@@ -1,0 +1,97 @@
+package statsrunner
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type StatsRunner struct {
+	pgxPoolConfig *pgxpool.Config
+	db            *pgxpool.Pool
+}
+
+func New(dbDSN string) (*StatsRunner, error) {
+	pgxPoolConfig, err := pgxpool.ParseConfig(dbDSN)
+	if err != nil {
+		return nil, err
+	}
+	return &StatsRunner{pgxPoolConfig: pgxPoolConfig}, nil
+}
+
+func (sr *StatsRunner) Start(ctx context.Context) error {
+	var err error
+	sr.db, err = pgxpool.NewWithConfig(ctx, sr.pgxPoolConfig)
+	return err
+}
+
+func (sr *StatsRunner) Close() {
+	sr.db.Close()
+}
+
+type EventSummary struct {
+	TotalAttempts              uint64    `json:"totalAttempts"`
+	AttemptedBitswap           uint64    `json:"attemptedBitswap"`
+	AttemptedGraphSync         uint64    `json:"attemptedGraphSync"`
+	AttemptedBoth              uint64    `json:"attemptedBoth"`
+	AttemptedEither            uint64    `json:"attemptedEither"`
+	BitswapSuccesses           uint64    `json:"bitswapSuccesses"`
+	GraphSyncSuccesses         uint64    `json:"graphSyncSuccesses"`
+	AvgBandwidth               *float64  `json:"avgBandwidth"`
+	FirstByte                  []float64 `json:"firstByte"`
+	DownloadSize               []float64 `json:"downloadSize"`
+	GraphsyncAttemptsPastQuery uint64    `json:"graphsyncAttemptsPastQuery"`
+}
+
+func (sr *StatsRunner) GetEventSummary(ctx context.Context) (*EventSummary, error) {
+
+	runQuery := `
+select count(all_attempts.retrieval_id) as total_attempts, 
+count(bitswap_retrievals.retrieval_id) as attempted_bitswap, 
+count(graphsync_retrievals.retrieval_id) as attempted_graphsync, 
+sum(case when bitswap_retrievals.retrieval_id IS NOT NULL and graphsync_retrievals.retrieval_id IS NOT NULL then 1 else 0 end) as attempted_both,
+sum(case when bitswap_retrievals.retrieval_id IS NOT NULL or graphsync_retrievals.retrieval_id IS NOT NULL then 1 else 0 end) as attempted_either,
+sum(case when successful_retrievals.storage_provider_id = 'Bitswap' then 1 else 0 end) as bitswap_successes,
+sum(case when successful_retrievals.storage_provider_id <> 'Bitswap' and successful_retrievals.retrieval_id IS NOT NULL then 1 else 0 end) as graphsync_successes,
+case when extract('epoch' from sum(successful_retrievals.event_time - first_byte_retrievals.event_time)) = 0 then 0 else sum(successful_retrievals.received_size)::float / extract('epoch' from sum(successful_retrievals.event_time - first_byte_retrievals.event_time))::float end as avg_bandwidth,
+percentile_cont('{0.5, 0.9, 0.95}'::double precision[]) WITHIN GROUP (ORDER BY (extract ('epoch' from first_byte_retrievals.event_time - all_attempts.event_time))) as p50_p90_p95_first_byte,
+percentile_cont('{0.5, 0.9, 0.95}'::double precision[]) WITHIN GROUP (ORDER BY (successful_retrievals.received_size)) as p50_p90_p95_download_size,
+count(graphsync_retrieval_attempts.retrieval_id) as graphsync_retrieval_attempts_past_query
+from (
+	select distinct on (retrieval_id) retrieval_id, event_time from retrieval_events order by retrieval_id, event_time
+	) as all_attempts left join (
+		select distinct retrieval_id from retrieval_events where storage_provider_id = 'Bitswap'
+		) as bitswap_retrievals on all_attempts.retrieval_id = bitswap_retrievals.retrieval_id left join (
+			select distinct retrieval_id from retrieval_events where storage_provider_id <> 'Bitswap' and phase <> 'indexer'
+			) as graphsync_retrievals on graphsync_retrievals.retrieval_id = all_attempts.retrieval_id left join (
+				select distinct on (retrieval_id) retrieval_id, event_time, storage_provider_id, (event_details ->	'receivedSize')::int8 as received_size from retrieval_events where event_name = 'success' order by retrieval_id, event_time
+			) as successful_retrievals on  successful_retrievals.retrieval_id = all_attempts.retrieval_id left join (
+				select retrieval_id, event_time, storage_provider_id from retrieval_events where event_name = 'first-byte-received'
+			) as first_byte_retrievals on successful_retrievals.retrieval_id = first_byte_retrievals.retrieval_id and successful_retrievals.storage_provider_id = first_byte_retrievals.storage_provider_id left join (
+				select distinct retrieval_id from retrieval_events where storage_provider_id <> 'Bitswap' and phase = 'retrieval'
+			) as graphsync_retrieval_attempts on graphsync_retrievals.retrieval_id = graphsync_retrieval_attempts.retrieval_id
+`
+
+	row := sr.db.QueryRow(ctx, runQuery)
+	var summary EventSummary
+	err := row.Scan(&summary.TotalAttempts,
+		&summary.AttemptedBitswap,
+		&summary.AttemptedGraphSync,
+		&summary.AttemptedBoth,
+		&summary.AttemptedEither,
+		&summary.BitswapSuccesses,
+		&summary.GraphSyncSuccesses,
+		&summary.AvgBandwidth,
+		&summary.FirstByte,
+		&summary.DownloadSize,
+		&summary.GraphsyncAttemptsPastQuery)
+
+	if err != nil {
+		return nil, err
+	}
+	return &summary, nil
+}
+
+func (sr *StatsRunner) WipeTable(ctx context.Context) {
+	sr.db.Exec(ctx, "TRUNCATE TABLE retrieval_events")
+}


### PR DESCRIPTION
# Goals

I realize this query is very temporary, but I want to make sure I'm doing this right by moving it to a seperate command that I can run from a spot instance with `kubectl exec`. Is this the correct way to do it? Or perhaps move to a seperate docker entirely?

Also I do need to run this query, if only once. To make sure I get the proper data for this week.