### PR TITLE
Add prefix to metric names and drop otel scope tags

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -28,7 +28,7 @@ func (m *Metrics) Start() error {
 	// The exporter embeds a default OpenTelemetry Reader and
 	// implements prometheus.Collector, allowing it to be used as
 	// both a Reader and Collector.
-	exporter, err := prometheus.New()
+	exporter, err := prometheus.New(prometheus.WithoutScopeInfo(), prometheus.WithoutTargetInfo())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -38,7 +38,7 @@ func (m *Metrics) Start() error {
 		// histogram buckets
 		metric.WithView(metric.NewView(
 			metric.Instrument{
-				Name:  "failed_retrievals_per_request_total",
+				Name:  meterName + "/failed_retrievals_per_request_total",
 				Scope: instrumentation.Scope{Name: meterName},
 			},
 			metric.Stream{
@@ -49,7 +49,7 @@ func (m *Metrics) Start() error {
 		),
 			metric.NewView(
 				metric.Instrument{
-					Name:  "indexer_candidates_per_request_total",
+					Name:  meterName + "/indexer_candidates_per_request_total",
 					Scope: instrumentation.Scope{Name: meterName},
 				},
 				metric.Stream{
@@ -60,7 +60,7 @@ func (m *Metrics) Start() error {
 			),
 			metric.NewView(
 				metric.Instrument{
-					Name:  "indexer_candidates_filtered_per_request_total",
+					Name:  meterName + "/indexer_candidates_filtered_per_request_total",
 					Scope: instrumentation.Scope{Name: meterName},
 				},
 				metric.Stream{
@@ -71,7 +71,7 @@ func (m *Metrics) Start() error {
 			),
 			metric.NewView(
 				metric.Instrument{
-					Name:  "retrieval_deal_duration_seconds",
+					Name:  meterName + "/retrieval_deal_duration_seconds",
 					Scope: instrumentation.Scope{Name: meterName},
 				},
 				metric.Stream{
@@ -82,7 +82,7 @@ func (m *Metrics) Start() error {
 			),
 			metric.NewView(
 				metric.Instrument{
-					Name:  "retrieval_deal_duration_seconds",
+					Name:  meterName + "/retrieval_deal_duration_seconds",
 					Scope: instrumentation.Scope{Name: meterName},
 				},
 				metric.Stream{
@@ -93,7 +93,7 @@ func (m *Metrics) Start() error {
 			),
 			metric.NewView(
 				metric.Instrument{
-					Name:  "time_to_first_indexer_result",
+					Name:  meterName + "/time_to_first_indexer_result",
 					Scope: instrumentation.Scope{Name: meterName},
 				},
 				metric.Stream{
@@ -104,7 +104,7 @@ func (m *Metrics) Start() error {
 			),
 			metric.NewView(
 				metric.Instrument{
-					Name:  "time_to_first_byte",
+					Name:  meterName + "/time_to_first_byte",
 					Scope: instrumentation.Scope{Name: meterName},
 				},
 				metric.Stream{
@@ -115,7 +115,7 @@ func (m *Metrics) Start() error {
 			),
 			metric.NewView(
 				metric.Instrument{
-					Name:  "retrieval_deal_size_bytes",
+					Name:  meterName + "/retrieval_deal_size_bytes",
 					Scope: instrumentation.Scope{Name: meterName},
 				},
 				metric.Stream{
@@ -126,7 +126,7 @@ func (m *Metrics) Start() error {
 			),
 			metric.NewView(
 				metric.Instrument{
-					Name:  "bandwidth_bytes_per_second",
+					Name:  meterName + "/bandwidth_bytes_per_second",
 					Scope: instrumentation.Scope{Name: meterName},
 				},
 				metric.Stream{
@@ -141,52 +141,52 @@ func (m *Metrics) Start() error {
 
 	// funnel
 
-	if m.totalRequestCount, err = meter.Int64Counter("total_request_count",
+	if m.totalRequestCount, err = meter.Int64Counter(meterName+"/total_request_count",
 		instrument.WithDescription("distinct retrievals sent to Lassie on Saturn"),
 	); err != nil {
 		return err
 	}
-	if m.requestWithIndexerFailures, err = meter.Int64Counter("requests_with_indexer_failures",
+	if m.requestWithIndexerFailures, err = meter.Int64Counter(meterName+"/requests_with_indexer_failures",
 		instrument.WithDescription("failures at the indexer phase"),
 	); err != nil {
 		return err
 	}
-	if m.requestWithIndexerCandidatesCount, err = meter.Int64Counter("request_with_indexer_candidates_total",
+	if m.requestWithIndexerCandidatesCount, err = meter.Int64Counter(meterName+"/request_with_indexer_candidates_total",
 		instrument.WithDescription("The number of requests that result in non-zero candidates from the indexer"),
 	); err != nil {
 		return err
 	}
-	if m.requestWithIndexerCandidatesFilteredCount, err = meter.Int64Counter("request_with_indexer_candidates_filtered_total",
+	if m.requestWithIndexerCandidatesFilteredCount, err = meter.Int64Counter(meterName+"/request_with_indexer_candidates_filtered_total",
 		instrument.WithDescription("The number of requests that result in non-zero candidates from the indexer after filtering"),
 	); err != nil {
 		return err
 	}
-	if m.requestWithBitswapAttempt, err = meter.Int64Counter("request_with_bitswap_attempts",
+	if m.requestWithBitswapAttempt, err = meter.Int64Counter(meterName+"/request_with_bitswap_attempts",
 		instrument.WithDescription("The number of requests where a bitswap retrieval was attempted"),
 	); err != nil {
 		return err
 	}
-	if m.requestWithGraphSyncAttempt, err = meter.Int64Counter("request_with_graphsync_attempts",
+	if m.requestWithGraphSyncAttempt, err = meter.Int64Counter(meterName+"/request_with_graphsync_attempts",
 		instrument.WithDescription("The number of requests where a graphsync retrieval was attempted"),
 	); err != nil {
 		return err
 	}
-	if m.requestWithFirstByteReceivedCount, err = meter.Int64Counter("request_with_first_byte_received",
+	if m.requestWithFirstByteReceivedCount, err = meter.Int64Counter(meterName+"/request_with_first_byte_received",
 		instrument.WithDescription("The number of requests where a non-zero number of bytes were received"),
 	); err != nil {
 		return err
 	}
-	if m.requestWithSuccessCount, err = meter.Int64Counter("request_with_success",
+	if m.requestWithSuccessCount, err = meter.Int64Counter(meterName+"/request_with_success",
 		instrument.WithDescription("The number of successful retrievals via lassie (all bytes received)"),
 	); err != nil {
 		return err
 	}
-	if m.requestWithBitswapSuccessCount, err = meter.Int64Counter("request_with_bitswap_success",
+	if m.requestWithBitswapSuccessCount, err = meter.Int64Counter(meterName+"/request_with_bitswap_success",
 		instrument.WithDescription("The number of successful retrievals via lassie (all bytes received) over bitswap"),
 	); err != nil {
 		return err
 	}
-	if m.requestWithGraphSyncSuccessCount, err = meter.Int64Counter("request_with_graphsync_success",
+	if m.requestWithGraphSyncSuccessCount, err = meter.Int64Counter(meterName+"/request_with_graphsync_success",
 		instrument.WithDescription("The number of successful retrievals via lassie (all bytes received) over graphsync"),
 	); err != nil {
 		return err
@@ -194,31 +194,31 @@ func (m *Metrics) Start() error {
 
 	// stats
 
-	if m.timeToFirstIndexerResult, err = meter.Float64Histogram("time_to_first_indexer_result",
+	if m.timeToFirstIndexerResult, err = meter.Float64Histogram(meterName+"/time_to_first_indexer_result",
 		instrument.WithDescription("The time to to first indexer result in seconds"),
 		instrument.WithUnit("seconds"),
 	); err != nil {
 		return err
 	}
-	if m.timeToFirstByte, err = meter.Float64Histogram("time_to_first_byte",
+	if m.timeToFirstByte, err = meter.Float64Histogram(meterName+"/time_to_first_byte",
 		instrument.WithDescription("The time to to first byte in seconds"),
 		instrument.WithUnit("seconds"),
 	); err != nil {
 		return err
 	}
-	if m.bandwidthBytesPerSecond, err = meter.Int64Histogram("bandwidth_bytes_per_second",
+	if m.bandwidthBytesPerSecond, err = meter.Int64Histogram(meterName+"/bandwidth_bytes_per_second",
 		instrument.WithDescription("average bytes transferred per second"),
 		instrument.WithUnit("seconds"),
 	); err != nil {
 		return err
 	}
-	if m.retrievalDealSize, err = meter.Int64Histogram("retrieval_deal_size_bytes",
+	if m.retrievalDealSize, err = meter.Int64Histogram(meterName+"/retrieval_deal_size_bytes",
 		instrument.WithDescription("The size in bytes of a retrieval deal with a storage provider"),
 		instrument.WithUnit("bytes"),
 	); err != nil {
 		return err
 	}
-	if m.retrievalDealDuration, err = meter.Float64Histogram("retrieval_deal_duration_seconds",
+	if m.retrievalDealDuration, err = meter.Float64Histogram(meterName+"/retrieval_deal_duration_seconds",
 		instrument.WithDescription("The duration in seconds of a retrieval deal with a storage provider"),
 		instrument.WithUnit("seconds"),
 	); err != nil {
@@ -226,59 +226,59 @@ func (m *Metrics) Start() error {
 	}
 
 	// errors
-	if m.retrievalErrorRejectedCount, err = meter.Int64Counter("retrieval_error_rejected_total",
+	if m.retrievalErrorRejectedCount, err = meter.Int64Counter(meterName+"/retrieval_error_rejected_total",
 		instrument.WithDescription("The number of retrieval errors for 'response rejected'"),
 	); err != nil {
 		return err
 	}
-	if m.retrievalErrorTooManyCount, err = meter.Int64Counter("retrieval_error_toomany_total",
+	if m.retrievalErrorTooManyCount, err = meter.Int64Counter(meterName+"/retrieval_error_toomany_total",
 		instrument.WithDescription("The number of retrieval errors for 'Too many retrieval deals received'"),
 	); err != nil {
 		return err
 	}
-	if m.retrievalErrorACLCount, err = meter.Int64Counter("retrieval_error_acl_total",
+	if m.retrievalErrorACLCount, err = meter.Int64Counter(meterName+"/retrieval_error_acl_total",
 		instrument.WithDescription("The number of retrieval errors for 'Access Control'"),
 	); err != nil {
 		return err
 	}
-	if m.retrievalErrorMaintenanceCount, err = meter.Int64Counter("retrieval_error_maintenance_total",
+	if m.retrievalErrorMaintenanceCount, err = meter.Int64Counter(meterName+"/retrieval_error_maintenance_total",
 		instrument.WithDescription("The number of retrieval errors for 'Under maintenance, retry later'"),
 	); err != nil {
 		return err
 	}
-	if m.retrievalErrorNoOnlineCount, err = meter.Int64Counter("retrieval_error_noonline_total",
+	if m.retrievalErrorNoOnlineCount, err = meter.Int64Counter(meterName+"/retrieval_error_noonline_total",
 		instrument.WithDescription("The number of retrieval errors for 'miner is not accepting online retrieval deals'"),
 	); err != nil {
 		return err
 	}
-	if m.retrievalErrorUnconfirmedCount, err = meter.Int64Counter("retrieval_error_unconfirmed_total",
+	if m.retrievalErrorUnconfirmedCount, err = meter.Int64Counter(meterName+"/retrieval_error_unconfirmed_total",
 		instrument.WithDescription("The number of retrieval errors for 'unconfirmed block transfer'"),
 	); err != nil {
 		return err
 	}
-	if m.retrievalErrorTimeoutCount, err = meter.Int64Counter("retrieval_error_timeout_total",
+	if m.retrievalErrorTimeoutCount, err = meter.Int64Counter(meterName+"/retrieval_error_timeout_total",
 		instrument.WithDescription("The number of retrieval errors for 'timeout after X'"),
 	); err != nil {
 		return err
 	}
-	if m.retrievalErrorOtherCount, err = meter.Int64Counter("retrieval_error_other_total",
+	if m.retrievalErrorOtherCount, err = meter.Int64Counter(meterName+"/retrieval_error_other_total",
 		instrument.WithDescription("The number of retrieval errors with uncategorized causes"),
 	); err != nil {
 		return err
 	}
 
 	// averages
-	if m.indexerCandidatesPerRequestCount, err = meter.Int64Histogram("indexer_candidates_per_request_total",
+	if m.indexerCandidatesPerRequestCount, err = meter.Int64Histogram(meterName+"/indexer_candidates_per_request_total",
 		instrument.WithDescription("The number of indexer candidates received per request"),
 	); err != nil {
 		return err
 	}
-	if m.indexerCandidatesFilteredPerRequestCount, err = meter.Int64Histogram("indexer_candidates_filtered_per_request_total",
+	if m.indexerCandidatesFilteredPerRequestCount, err = meter.Int64Histogram(meterName+"/indexer_candidates_filtered_per_request_total",
 		instrument.WithDescription("The number of filtered indexer candidates received per request"),
 	); err != nil {
 		return err
 	}
-	if m.failedRetrievalsPerRequestCount, err = meter.Int64Histogram("failed_retrievals_per_request_total",
+	if m.failedRetrievalsPerRequestCount, err = meter.Int64Histogram(meterName+"/failed_retrievals_per_request_total",
 		instrument.WithDescription("The number of failed retrieval attempts per request"),
 	); err != nil {
 		return err


### PR DESCRIPTION
Otel API does not prefix metrics with name and adds scope and target tags by default. Add prefix and disable redundant tags.