### PR TITLE
Add tracking of graphsync failures

### DIFF
--- a/eventrecorder/recorder.go
+++ b/eventrecorder/recorder.go
@@ -80,7 +80,7 @@ func (r *EventRecorder) RecordEvents(ctx context.Context, events []Event) error 
 			case types.CandidatesFilteredCode:
 				r.cfg.metrics.HandleCandidatesFilteredEvent(ctx, event.RetrievalId, event.EventDetails)
 			case types.FailedCode:
-				r.cfg.metrics.HandleFailureEvent(ctx, event.RetrievalId, event.Phase, event.EventDetails)
+				r.cfg.metrics.HandleFailureEvent(ctx, event.RetrievalId, event.Phase, event.StorageProviderId, event.EventDetails)
 			case types.FirstByteCode:
 				r.cfg.metrics.HandleTimeToFirstByteEvent(ctx, event.RetrievalId, event.StorageProviderId, event.EventTime)
 			case types.SuccessCode:

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -225,6 +225,12 @@ func (m *Metrics) Start() error {
 		return err
 	}
 
+	if m.graphsyncRetrievalFailureCount, err = meter.Int64Counter(meterName+"/graphsync__retrieval_failure_total",
+		instrument.WithDescription("The graphsync requests that completed with a failure status"),
+	); err != nil {
+		return err
+	}
+
 	// errors
 	if m.retrievalErrorRejectedCount, err = meter.Int64Counter(meterName+"/retrieval_error_rejected_total",
 		instrument.WithDescription("The number of retrieval errors for 'response rejected'"),
@@ -300,6 +306,7 @@ type stats struct {
 	requestWithSuccessCount                   instrument.Int64Counter
 	requestWithBitswapSuccessCount            instrument.Int64Counter
 	requestWithGraphSyncSuccessCount          instrument.Int64Counter
+	graphsyncRetrievalFailureCount            instrument.Int64Counter
 
 	// stats
 	timeToFirstIndexerResult instrument.Float64Histogram


### PR DESCRIPTION
# Goals

Determine how often initiated graphsync requests are actually failing, versus just getting cancelled..

# Implementation

- Add a failure count for graphsync requests that actually fail
- also tag our errors by protocol so we can filter them.

# For discussion

The failure here is a bit divergent with how we count things elsewhere. Most of our other metrics are "0 or 1 per request" -- i.e. across the entire request, it either happened or didn't happen. However you can get multiple failures with SPs. While we can record failures on a per request basis, I think it's more informative in terms of "are SPs succeeding" to count each failed attempt individually.