### PR TITLE
Don't consider events without a remote peer in reports to mongo

### DIFF
--- a/eventrecorder/recorder.go
+++ b/eventrecorder/recorder.go
@@ -214,7 +214,10 @@ func (r *EventRecorder) RecordAggregateEvents(ctx context.Context, events []Aggr
 				attempts,
 			)
 		}
-		if r.mongo != nil && rand.Float32() < r.cfg.mongoPercentile {
+
+		if r.mongo != nil &&
+			rand.Float32() < r.cfg.mongoPercentile &&
+			event.StorageProviderID != "bitswap" {
 			_, err := r.mc.InsertOne(ctx, bson.D{
 				{Key: "retrieval_id", Value: event.RetrievalID},
 				{Key: "instance_id", Value: event.InstanceID},


### PR DESCRIPTION
bitswap aggregate events not specifying a peer don't fit the schema of mongo reports, so don't report them.