### PR TITLE
Tag container images with sortable string

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -29,7 +29,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           tags: |
+            type=ref,event=branch
+            type=sha,format=long
             type=semver,pattern={{version}}
+            type=raw,value={{date 'YYYYMMDD-hhmmss'}}-{{sha}}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4


### PR DESCRIPTION
In order to enable CD pipeline to fetch the most recent image using tag build and push containers with a sortable tag that includes the build timestamp.

For ease of debugging, also tag images with the long sha and branch.