### PR TITLE
Add ProtocolSucceeded to aggregated event

### DIFF
--- a/eventrecorder/event.go
+++ b/eventrecorder/event.go
@@ -141,6 +141,7 @@ type AggregateEvent struct {
 	IndexerCandidatesFiltered int                          `json:"indexerCandidatesFiltered"`          // The number of candidates that made it through the filtering stage
 	ProtocolsAllowed          []string                     `json:"protocolsAllowed,omitempty"`         // The available protocols that could be used for this retrieval
 	ProtocolsAttempted        []string                     `json:"protocolsAttempted,omitempty"`       // The protocols that were used to attempt this retrieval
+	ProtocolSucceeded         string                       `json:"protocolSucceeded,omitempty"`        // The protocol used for a successful event
 	RetrievalAttempts         map[string]*RetrievalAttempt `json:"retrievalAttempts,omitempty"`        // All of the retrieval attempts, indexed by their SP ID
 }
 

--- a/eventrecorder/event.go
+++ b/eventrecorder/event.go
@@ -123,6 +123,7 @@ func (e EventBatch) Validate() error {
 type RetrievalAttempt struct {
 	Error           string `json:"error,omitempty"`
 	TimeToFirstByte string `json:"timeToFirstByte,omitempty"`
+	Protocol        string `json:"protocol,omitempty"`
 }
 
 type AggregateEvent struct {

--- a/eventrecorder/recorder.go
+++ b/eventrecorder/recorder.go
@@ -137,9 +137,10 @@ func (r *EventRecorder) RecordAggregateEvents(ctx context.Context, events []Aggr
 			indexer_candidates_received,
 			indexer_candidates_filtered,
 			protocols_allowed,
-			protocols_attempted
+			protocols_attempted,
+			protocol_succeeded
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 		`
 		batchQuery.Queue(query,
 			event.InstanceID,
@@ -156,6 +157,7 @@ func (r *EventRecorder) RecordAggregateEvents(ctx context.Context, events []Aggr
 			event.IndexerCandidatesFiltered,
 			event.ProtocolsAllowed,
 			event.ProtocolsAttempted,
+			event.ProtocolSucceeded,
 		).Exec(func(ct pgconn.CommandTag) error {
 			rowsAffected := ct.RowsAffected()
 			switch rowsAffected {
@@ -211,6 +213,7 @@ func (r *EventRecorder) RecordAggregateEvents(ctx context.Context, events []Aggr
 				int64(event.IndexerCandidatesReceived),
 				int64(event.IndexerCandidatesFiltered),
 				attempts,
+				event.ProtocolSucceeded,
 			)
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/multiformats/go-multiaddr v0.8.0 // indirect
 	github.com/multiformats/go-multibase v0.1.1 // indirect
-	github.com/multiformats/go-multicodec v0.8.1 // indirect
+	github.com/multiformats/go-multicodec v0.9.0 // indirect
 	github.com/multiformats/go-multihash v0.2.1 // indirect
 	github.com/multiformats/go-multistream v0.4.1 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ipfs/go-cid v0.3.2
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/jackc/pgx/v5 v5.3.1
+	github.com/multiformats/go-multicodec v0.9.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/stretchr/testify v1.8.2
 	go.mongodb.org/mongo-driver v1.11.4
@@ -81,7 +82,6 @@ require (
 	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/multiformats/go-multiaddr v0.8.0 // indirect
 	github.com/multiformats/go-multibase v0.1.1 // indirect
-	github.com/multiformats/go-multicodec v0.9.0 // indirect
 	github.com/multiformats/go-multihash v0.2.1 // indirect
 	github.com/multiformats/go-multistream v0.4.1 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,6 @@ github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/g
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
 github.com/multiformats/go-multibase v0.1.1 h1:3ASCDsuLX8+j4kx58qnJ4YFq/JWTJpCyDW27ztsVTOI=
 github.com/multiformats/go-multibase v0.1.1/go.mod h1:ZEjHE+IsUrgp5mhlEAYjMtZwK1k4haNkcaPg9aoe1a8=
-github.com/multiformats/go-multicodec v0.8.1 h1:ycepHwavHafh3grIbR1jIXnKCsFm0fqsfEOsJ8NtKE8=
-github.com/multiformats/go-multicodec v0.8.1/go.mod h1:L3QTQvMIaVBkXOXXtVmYE+LI16i14xuaojr/H7Ai54k=
 github.com/multiformats/go-multicodec v0.9.0 h1:pb/dlPnzee/Sxv/j4PmkDRxCOi3hXTz3IbPKOXWJkmg=
 github.com/multiformats/go-multicodec v0.9.0/go.mod h1:L3QTQvMIaVBkXOXXtVmYE+LI16i14xuaojr/H7Ai54k=
 github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKTwfvkofsjW2Qa1ct4U=

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,8 @@ github.com/multiformats/go-multibase v0.1.1 h1:3ASCDsuLX8+j4kx58qnJ4YFq/JWTJpCyD
 github.com/multiformats/go-multibase v0.1.1/go.mod h1:ZEjHE+IsUrgp5mhlEAYjMtZwK1k4haNkcaPg9aoe1a8=
 github.com/multiformats/go-multicodec v0.8.1 h1:ycepHwavHafh3grIbR1jIXnKCsFm0fqsfEOsJ8NtKE8=
 github.com/multiformats/go-multicodec v0.8.1/go.mod h1:L3QTQvMIaVBkXOXXtVmYE+LI16i14xuaojr/H7Ai54k=
+github.com/multiformats/go-multicodec v0.9.0 h1:pb/dlPnzee/Sxv/j4PmkDRxCOi3hXTz3IbPKOXWJkmg=
+github.com/multiformats/go-multicodec v0.9.0/go.mod h1:L3QTQvMIaVBkXOXXtVmYE+LI16i14xuaojr/H7Ai54k=
 github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKTwfvkofsjW2Qa1ct4U=
 github.com/multiformats/go-multihash v0.0.9/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=
 github.com/multiformats/go-multihash v0.0.10/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=

--- a/metrics/events.go
+++ b/metrics/events.go
@@ -205,7 +205,8 @@ func (m *Metrics) HandleAggregatedEvent(ctx context.Context,
 			failureCount += 0
 		}
 		if attempt.TimeToFirstByte != time.Duration(0) && (lowestTTFB == time.Duration(0) || attempt.TimeToFirstByte < lowestTTFB) {
-			lowestTTFBProtocol = protocolAttempted
+			lowestTTFB = attempt.TimeToFirstByte
+			lowestTTFBProtocol = protocolFromMulticodecString(attempt.Protocol)
 		}
 	}
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -191,6 +191,11 @@ func (m *Metrics) Start() error {
 	); err != nil {
 		return err
 	}
+	if m.requestWithHttpSuccessCount, err = meter.Int64Counter(meterName+"/request_with_http_success",
+		instrument.WithDescription("The number of successful retrievals via lassie (all bytes received) over http"),
+	); err != nil {
+		return err
+	}
 
 	// stats
 
@@ -327,6 +332,7 @@ type stats struct {
 	requestWithSuccessCount                   instrument.Int64Counter
 	requestWithBitswapSuccessCount            instrument.Int64Counter
 	requestWithGraphSyncSuccessCount          instrument.Int64Counter
+	requestWithHttpSuccessCount               instrument.Int64Counter
 	graphsyncRetrievalFailureCount            instrument.Int64Counter
 
 	// stats

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -171,6 +171,11 @@ func (m *Metrics) Start() error {
 	); err != nil {
 		return err
 	}
+	if m.requestWithHttpAttempt, err = meter.Int64Counter(meterName+"/request_with_http_attempts",
+		instrument.WithDescription("The number of requests where an http retrieval was attempted"),
+	); err != nil {
+		return err
+	}
 	if m.requestWithFirstByteReceivedCount, err = meter.Int64Counter(meterName+"/request_with_first_byte_received",
 		instrument.WithDescription("The number of requests where a non-zero number of bytes were received"),
 	); err != nil {
@@ -235,7 +240,11 @@ func (m *Metrics) Start() error {
 	); err != nil {
 		return err
 	}
-
+	if m.httpRetrievalFailureCount, err = meter.Int64Counter(meterName+"/http__retrieval_failure_total",
+		instrument.WithDescription("The http requests that completed with a failure status"),
+	); err != nil {
+		return err
+	}
 	// errors
 	if m.retrievalErrorRejectedCount, err = meter.Int64Counter(meterName+"/retrieval_error_rejected_total",
 		instrument.WithDescription("The number of retrieval errors for 'response rejected'"),
@@ -326,6 +335,7 @@ type stats struct {
 	requestWithIndexerFailures                instrument.Int64Counter
 	requestWithIndexerCandidatesCount         instrument.Int64Counter
 	requestWithIndexerCandidatesFilteredCount instrument.Int64Counter
+	requestWithHttpAttempt                    instrument.Int64Counter
 	requestWithBitswapAttempt                 instrument.Int64Counter
 	requestWithGraphSyncAttempt               instrument.Int64Counter
 	requestWithFirstByteReceivedCount         instrument.Int64Counter
@@ -333,6 +343,7 @@ type stats struct {
 	requestWithBitswapSuccessCount            instrument.Int64Counter
 	requestWithGraphSyncSuccessCount          instrument.Int64Counter
 	requestWithHttpSuccessCount               instrument.Int64Counter
+	httpRetrievalFailureCount                 instrument.Int64Counter
 	graphsyncRetrievalFailureCount            instrument.Int64Counter
 
 	// stats

--- a/schema.sql
+++ b/schema.sql
@@ -24,7 +24,8 @@ create table if not exists aggregate_retrieval_events(
 	indexer_candidates_received integer,
 	indexer_candidates_filtered integer,
 	protocols_allowed        varchar[256][],    
-	protocols_attempted      varchar[256][]
+	protocols_attempted      varchar[256][],
+  protocol_succeeded       varchar[256]
 );
 
 create table if not exists retrieval_attempts(

--- a/schema.sql
+++ b/schema.sql
@@ -32,6 +32,7 @@ create table if not exists retrieval_attempts(
   retrieval_id uuid not null,
   storage_provider_id character varying(256),
   time_to_first_byte int8,
-  error character varying(256),
+  error text,
+  protocol varchar[256],
   FOREIGN KEY (retrieval_id) REFERENCES aggregate_retrieval_events (retrieval_id)
 );


### PR DESCRIPTION
Adds processing of the `ProtocolSucceeded` property on the aggregated event. This update is related to [Lassie PR #252](https://github.com/filecoin-project/lassie/pull/252) where the property is added to the event.

I also made a minor attempt to update the metric collection on a success using the new protocol string we now have from new property. I added the `requestWithHttpSuccessCount` metric counter to match the other counters.

In reference to [Lassie Issue #242](https://github.com/filecoin-project/lassie/issues/247)