### PR TITLE
Use all five values in insert statement

### DIFF
--- a/eventrecorder/recorder.go
+++ b/eventrecorder/recorder.go
@@ -187,7 +187,7 @@ func (r *EventRecorder) RecordAggregateEvents(ctx context.Context, events []Aggr
 			  storage_provider_id,
 			  time_to_first_byte,
 			  error,
-				protocol
+			  protocol
 		  )
 		  VALUES ($1, $2, $3, $4, $5)
 		  `

--- a/eventrecorder/recorder.go
+++ b/eventrecorder/recorder.go
@@ -189,7 +189,7 @@ func (r *EventRecorder) RecordAggregateEvents(ctx context.Context, events []Aggr
 			  error,
 				protocol
 		  )
-		  VALUES ($1, $2, $3, $4)
+		  VALUES ($1, $2, $3, $4, $5)
 		  `
 			batchRetrievalAttempts.Queue(query,
 				event.RetrievalID,


### PR DESCRIPTION
We were only inserting four values into an insert statement that used five columns, causing the following error in our logs.

```
INSERT has more target columns than expressions (SQLSTATE 42601)
```