### PR TITLE
chore: add protocol label to success count metric

### DIFF
--- a/metrics/events.go
+++ b/metrics/events.go
@@ -226,7 +226,7 @@ func (m *Metrics) HandleAggregatedEvent(ctx context.Context,
 	if success {
 		protocol := protocolFromMulticodecString(protocolSucceeded)
 
-		m.requestWithSuccessCount.Add(ctx, 1)
+		m.requestWithSuccessCount.Add(ctx, 1, attribute.String("protocol", protocol))
 		switch protocol {
 		case ProtocolBitswap:
 			m.requestWithBitswapSuccessCount.Add(ctx, 1)


### PR DESCRIPTION
Adds the "protocol" label to the prometheus metric so that we can filter success counts by protocol.