### PR TITLE
feat: pass filecoin SPID to metrics reporter

### DIFF
--- a/eventrecorder/recorder_test.go
+++ b/eventrecorder/recorder_test.go
@@ -1,0 +1,276 @@
+package eventrecorder_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/lassie-event-recorder/eventrecorder"
+	"github.com/filecoin-project/lassie-event-recorder/httpserver"
+	"github.com/filecoin-project/lassie-event-recorder/metrics"
+	"github.com/filecoin-project/lassie-event-recorder/spmap"
+	spmaptestutil "github.com/filecoin-project/lassie-event-recorder/spmap/testutil"
+	"github.com/filecoin-project/lassie/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+var expectedEvents = []ae{
+	// bitswap success
+	{
+		timeToFirstIndexerResult: 10 * time.Millisecond,
+		timeToFirstByte:          40 * time.Millisecond,
+		success:                  true,
+		storageProviderID:        "Bitswap",
+		filSPID:                  "",
+		startTime:                time.Unix(0, 0).In(time.FixedZone("UTC+10", 10*60*60)),
+		endTime:                  time.Unix(0, 0).Add(90 * time.Millisecond).In(time.FixedZone("UTC+10", 10*60*60)),
+		bandwidth:                200000,
+		bytesTransferred:         10000,
+		indexerCandidates:        5,
+		indexerFiltered:          3,
+		protocolSucceeded:        "transport-bitswap",
+		attempts: map[string]metrics.Attempt{
+			"12D3KooWEqwTBN3GE4vT6DWZiKpq24UtSBmhhwM73vg7SfTjYWaF": {
+				Error:           "",
+				Protocol:        "transport-graphsync-filecoinv1",
+				TimeToFirstByte: 50 * time.Millisecond,
+			},
+			"12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqu": {
+				Error:    "failed to dial",
+				Protocol: "transport-graphsync-filecoinv1",
+			},
+			"Bitswap": {
+				Error:           "",
+				Protocol:        "transport-bitswap",
+				TimeToFirstByte: 20 * time.Millisecond,
+			},
+		},
+	},
+	// failure
+	{
+		timeToFirstIndexerResult: time.Duration(0),
+		timeToFirstByte:          time.Duration(0),
+		success:                  false,
+		storageProviderID:        "",
+		filSPID:                  "",
+		startTime:                time.Unix(0, 0).In(time.FixedZone("UTC+10", 10*60*60)),
+		endTime:                  time.Unix(0, 0).In(time.FixedZone("UTC+10", 10*60*60)),
+		bandwidth:                0,
+		bytesTransferred:         0,
+		indexerCandidates:        0,
+		indexerFiltered:          0,
+		protocolSucceeded:        "",
+		attempts:                 map[string]metrics.Attempt{},
+	},
+	// http success
+	{
+		timeToFirstIndexerResult: 20 * time.Millisecond,
+		timeToFirstByte:          80 * time.Millisecond,
+		success:                  true,
+		storageProviderID:        "12D3KooWDGBkHBZye7rN6Pz9ihEZrHnggoVRQh6eEtKP4z1K4KeE", // same as smpap/testutil/TestPeerID
+		filSPID:                  "f01228000",                                            // from Heyfil, same as smpap/testutil/TestSPID
+		startTime:                time.Unix(0, 0).Add(20 * time.Millisecond).In(time.FixedZone("UTC+10", 10*60*60)),
+		endTime:                  time.Unix(0, 0).Add(180 * time.Millisecond).In(time.FixedZone("UTC+10", 10*60*60)),
+		bandwidth:                300000,
+		bytesTransferred:         20000,
+		indexerCandidates:        10,
+		indexerFiltered:          6,
+		protocolSucceeded:        "transport-ipfs-gateway-http",
+		attempts: map[string]metrics.Attempt{
+			"12D3KooWDGBkHBZye7rN6Pz9ihEZrHnggoVRQh6eEtKP4z1K4KeE": {
+				Error:           "",
+				Protocol:        "transport-ipfs-gateway-http",
+				TimeToFirstByte: 100 * time.Millisecond,
+			},
+			"12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqu": {
+				Error:    "failed to dial",
+				Protocol: "transport-graphsync-filecoinv1",
+			},
+			"Bitswap": {
+				Error:           "",
+				Protocol:        "transport-bitswap",
+				TimeToFirstByte: 200 * time.Millisecond,
+			},
+		},
+	},
+}
+
+func TestRecorderMetrics(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req := require.New(t)
+
+	spmapts := httptest.NewServer(spmaptestutil.MockHeyfilHandler)
+	defer spmapts.Close()
+
+	mm := &mockMetrics{t: t}
+	recorder, err := eventrecorder.New(eventrecorder.WithMetrics(mm), eventrecorder.WithSPMapOptions(spmap.WithHeyFil(spmapts.URL)))
+	req.NoError(err)
+
+	handler := httpserver.NewHttpHandler(recorder)
+	evtts := httptest.NewServer(handler.Handler())
+	defer evtts.Close()
+
+	req.NoError(handler.Start(ctx))
+
+	encEventBatch, err := os.ReadFile("../testdata/aggregategood.json")
+	req.NoError(err)
+
+	resp, err := http.Post(
+		evtts.URL+"/v2/retrieval-events",
+		"application/json",
+		bytes.NewReader(encEventBatch))
+	req.NoError(err)
+	body, err := io.ReadAll(resp.Body)
+	req.NoError(err)
+	req.Equal(http.StatusOK, resp.StatusCode, string(body))
+	req.Len(body, 0)
+
+	req.Len(mm.aggregatedEvents, len(expectedEvents))
+	for ii, ee := range expectedEvents {
+		req.Equal(ee.timeToFirstIndexerResult, mm.aggregatedEvents[ii].timeToFirstIndexerResult)
+		req.Equal(ee.timeToFirstByte, mm.aggregatedEvents[ii].timeToFirstByte)
+		req.Equal(ee.success, mm.aggregatedEvents[ii].success)
+		req.Equal(ee.storageProviderID, mm.aggregatedEvents[ii].storageProviderID)
+		req.Equal(ee.filSPID, mm.aggregatedEvents[ii].filSPID)
+		req.Equal(ee.startTime.UTC(), mm.aggregatedEvents[ii].startTime.UTC())
+		req.Equal(ee.endTime.UTC(), mm.aggregatedEvents[ii].endTime.UTC())
+		req.Equal(ee.bandwidth, mm.aggregatedEvents[ii].bandwidth)
+		req.Equal(ee.bytesTransferred, mm.aggregatedEvents[ii].bytesTransferred)
+		req.Equal(ee.indexerCandidates, mm.aggregatedEvents[ii].indexerCandidates)
+		req.Equal(ee.indexerFiltered, mm.aggregatedEvents[ii].indexerFiltered)
+		req.Equal(ee.protocolSucceeded, mm.aggregatedEvents[ii].protocolSucceeded)
+		req.Len(mm.aggregatedEvents[ii].attempts, len(ee.attempts))
+		for k, aa := range ee.attempts {
+			req.Contains(mm.aggregatedEvents[ii].attempts, k)
+			req.Equal(aa.Error, mm.aggregatedEvents[ii].attempts[k].Error)
+			req.Equal(aa.Protocol, mm.aggregatedEvents[ii].attempts[k].Protocol)
+			req.Equal(aa.TimeToFirstByte, mm.aggregatedEvents[ii].attempts[k].TimeToFirstByte)
+		}
+	}
+}
+
+type mockMetrics struct {
+	t                *testing.T
+	aggregatedEvents []ae
+}
+
+func (mm *mockMetrics) HandleStartedEvent(context.Context, types.RetrievalID, types.Phase, time.Time, string) {
+	require.Fail(mm.t, "unexpected HandleStartedEvent call")
+}
+
+func (mm *mockMetrics) HandleCandidatesFoundEvent(context.Context, types.RetrievalID, time.Time, any) {
+	require.Fail(mm.t, "unexpected HandleCandidatesFoundEvent call")
+}
+
+func (mm *mockMetrics) HandleCandidatesFilteredEvent(context.Context, types.RetrievalID, any) {
+	require.Fail(mm.t, "unexpected HandleCandidatesFilteredEvent call")
+}
+
+func (mm *mockMetrics) HandleFailureEvent(context.Context, types.RetrievalID, types.Phase, string, any) {
+	require.Fail(mm.t, "unexpected HandleFailureEvent call")
+}
+
+func (mm *mockMetrics) HandleTimeToFirstByteEvent(context.Context, types.RetrievalID, string, time.Time) {
+	require.Fail(mm.t, "unexpected HandleTimeToFirstByteEvent call")
+}
+
+func (mm *mockMetrics) HandleSuccessEvent(context.Context, types.RetrievalID, time.Time, string, any) {
+	require.Fail(mm.t, "unexpected HandleSuccessEvent call")
+}
+
+func (mm *mockMetrics) HandleAggregatedEvent(
+	ctx context.Context,
+	timeToFirstIndexerResult time.Duration,
+	timeToFirstByte time.Duration,
+	success bool,
+	storageProviderID string, // Lassie Peer ID
+	filSPID string, // Heyfil Filecoin SP ID
+	startTime time.Time,
+	endTime time.Time,
+	bandwidth int64,
+	bytesTransferred int64,
+	indexerCandidates int64,
+	indexerFiltered int64,
+	attempts map[string]metrics.Attempt,
+	protocolSucceeded string,
+) {
+	if mm.aggregatedEvents == nil {
+		mm.aggregatedEvents = make([]ae, 0)
+	}
+	mm.aggregatedEvents = append(mm.aggregatedEvents, ae{
+		timeToFirstIndexerResult,
+		timeToFirstByte,
+		success,
+		storageProviderID,
+		filSPID,
+		startTime,
+		endTime,
+		bandwidth,
+		bytesTransferred,
+		indexerCandidates,
+		indexerFiltered,
+		attempts,
+		protocolSucceeded,
+	})
+}
+
+type ae struct {
+	timeToFirstIndexerResult time.Duration
+	timeToFirstByte          time.Duration
+	success                  bool
+	storageProviderID        string // Lassie Peer ID
+	filSPID                  string // Heyfil Filecoin SP ID
+	startTime                time.Time
+	endTime                  time.Time
+	bandwidth                int64
+	bytesTransferred         int64
+	indexerCandidates        int64
+	indexerFiltered          int64
+	attempts                 map[string]metrics.Attempt
+	protocolSucceeded        string
+}
+
+func (a ae) String() string {
+	attempts := strings.Builder{}
+	for k, v := range a.attempts {
+		attempts.WriteString(fmt.Sprintf("\t%s: error=%v, protocol=%v, ttfb=%v\n", k, v.Error, v.Protocol, v.TimeToFirstByte))
+	}
+
+	return fmt.Sprintf(
+		"timeToFirstIndexerResult: %v\n"+
+			"timeToFirstByte: %v\n"+
+			"success: %v\n"+
+			"storageProviderID: %s\n"+
+			"filSPID: %s\n"+
+			"startTime: %v\n"+
+			"endTime: %v\n"+
+			"bandwidth: %d\n"+
+			"bytesTransferred: %d\n"+
+			"indexerCandidates: %d\n"+
+			"indexerFiltered: %d\n"+
+			"attempts:\n%s"+
+			"protocolSucceeded: %s",
+		a.timeToFirstIndexerResult,
+		a.timeToFirstByte,
+		a.success,
+		a.storageProviderID,
+		a.filSPID,
+		a.startTime,
+		a.endTime,
+		a.bandwidth,
+		a.bytesTransferred,
+		a.indexerCandidates,
+		a.indexerFiltered,
+		attempts.String(),
+		a.protocolSucceeded,
+	)
+}

--- a/metrics/events.go
+++ b/metrics/events.go
@@ -156,7 +156,8 @@ func (m *Metrics) HandleAggregatedEvent(ctx context.Context,
 	timeToFirstIndexerResult time.Duration,
 	timeToFirstByte time.Duration,
 	success bool,
-	storageProviderID string,
+	storageProviderID string, // Lassie Peer ID
+	filSPID string, // Heyfil Filecoin SP ID
 	startTime time.Time,
 	endTime time.Time,
 	bandwidth int64,
@@ -226,14 +227,14 @@ func (m *Metrics) HandleAggregatedEvent(ctx context.Context,
 	if success {
 		protocol := protocolFromMulticodecString(protocolSucceeded)
 
-		m.requestWithSuccessCount.Add(ctx, 1, attribute.String("protocol", protocol))
+		m.requestWithSuccessCount.Add(ctx, 1, attribute.String("protocol", protocol), attribute.String("fil_sp_id", filSPID))
 		switch protocol {
 		case ProtocolBitswap:
 			m.requestWithBitswapSuccessCount.Add(ctx, 1, attribute.String("protocol", "bitswap"))
 		case ProtocolGraphsync:
-			m.requestWithGraphSyncSuccessCount.Add(ctx, 1, attribute.String("protocol", "graphsync"), attribute.String("sp_id", storageProviderID))
+			m.requestWithGraphSyncSuccessCount.Add(ctx, 1, attribute.String("protocol", "graphsync"), attribute.String("sp_id", storageProviderID), attribute.String("fil_sp_id", filSPID))
 		case ProtocolHttp:
-			m.requestWithHttpSuccessCount.Add(ctx, 1, attribute.String("protocol", "http"), attribute.String("sp_id", storageProviderID))
+			m.requestWithHttpSuccessCount.Add(ctx, 1, attribute.String("protocol", "http"), attribute.String("sp_id", storageProviderID), attribute.String("fil_sp_id", filSPID))
 		}
 
 		m.retrievalDealDuration.Record(ctx, endTime.Sub(startTime).Seconds(), attribute.String("protocol", protocol))

--- a/spmap/spmap.go
+++ b/spmap/spmap.go
@@ -16,7 +16,7 @@ import (
 
 var logger = log.Logger("lassie/spmap")
 
-type Option func(spConfig)
+type Option func(*spConfig)
 
 func NewSPMap(opts ...Option) *SPMap {
 	cf := spConfig{
@@ -24,7 +24,7 @@ func NewSPMap(opts ...Option) *SPMap {
 		client:         http.DefaultClient,
 	}
 	for _, o := range opts {
-		o(cf)
+		o(&cf)
 	}
 	arc, err := lru.NewARC(10_000)
 	if err != nil {
@@ -46,13 +46,13 @@ type spConfig struct {
 }
 
 func WithHeyFil(endpoint string) Option {
-	return func(sc spConfig) {
+	return func(sc *spConfig) {
 		sc.heyFilEndpoint = endpoint
 	}
 }
 
 func WithClient(c *http.Client) Option {
-	return func(sc spConfig) {
+	return func(sc *spConfig) {
 		sc.client = c
 	}
 }

--- a/spmap/spmap_test.go
+++ b/spmap/spmap_test.go
@@ -2,41 +2,23 @@ package spmap_test
 
 import (
 	"context"
-	"fmt"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/filecoin-project/lassie-event-recorder/spmap"
+	"github.com/filecoin-project/lassie-event-recorder/spmap/testutil"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-var (
-	TestPeerID = "12D3KooWDGBkHBZye7rN6Pz9ihEZrHnggoVRQh6eEtKP4z1K4KeE"
-	TestSPID   = "f01228000"
-)
-
-var MockHeyfilHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/sp" {
-		http.Error(w, "nope, bad path", http.StatusBadRequest)
-		return
-	}
-	if r.URL.RawQuery != "peerid="+TestPeerID {
-		http.Error(w, "nope, bad query", http.StatusBadRequest)
-		return
-	}
-	fmt.Fprintf(w, `["%s"]\n`, TestSPID)
-})
-
 func TestSPMap(t *testing.T) {
-	ts := httptest.NewServer(MockHeyfilHandler)
+	ts := httptest.NewServer(testutil.MockHeyfilHandler)
 	defer ts.Close()
 	spm := spmap.NewSPMap(spmap.WithHeyFil(ts.URL))
 	var pid peer.ID
-	pid.UnmarshalText([]byte(TestPeerID))
+	pid.UnmarshalText([]byte(testutil.TestPeerID))
 	ch := spm.Get(context.Background(), pid)
 	sid, ok := <-ch
-	if sid != TestSPID {
+	if sid != testutil.TestSPID {
 		t.Fatalf("unexpected response; got: %v / %t", sid, ok)
 	}
 }

--- a/spmap/spmap_test.go
+++ b/spmap/spmap_test.go
@@ -2,19 +2,41 @@ package spmap_test
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/filecoin-project/lassie-event-recorder/spmap"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
+var (
+	TestPeerID = "12D3KooWDGBkHBZye7rN6Pz9ihEZrHnggoVRQh6eEtKP4z1K4KeE"
+	TestSPID   = "f01228000"
+)
+
+var MockHeyfilHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/sp" {
+		http.Error(w, "nope, bad path", http.StatusBadRequest)
+		return
+	}
+	if r.URL.RawQuery != "peerid="+TestPeerID {
+		http.Error(w, "nope, bad query", http.StatusBadRequest)
+		return
+	}
+	fmt.Fprintf(w, `["%s"]\n`, TestSPID)
+})
+
 func TestSPMap(t *testing.T) {
-	spm := spmap.NewSPMap()
+	ts := httptest.NewServer(MockHeyfilHandler)
+	defer ts.Close()
+	spm := spmap.NewSPMap(spmap.WithHeyFil(ts.URL))
 	var pid peer.ID
-	pid.UnmarshalText([]byte("12D3KooWDGBkHBZye7rN6Pz9ihEZrHnggoVRQh6eEtKP4z1K4KeE"))
+	pid.UnmarshalText([]byte(TestPeerID))
 	ch := spm.Get(context.Background(), pid)
 	sid, ok := <-ch
-	if sid != "f01228000" {
+	if sid != TestSPID {
 		t.Fatalf("unexpected response; got: %v / %t", sid, ok)
 	}
 }

--- a/spmap/testutil/mockhandler.go
+++ b/spmap/testutil/mockhandler.go
@@ -1,0 +1,23 @@
+package testutil
+
+import (
+	"fmt"
+	"net/http"
+)
+
+var (
+	TestPeerID = "12D3KooWDGBkHBZye7rN6Pz9ihEZrHnggoVRQh6eEtKP4z1K4KeE"
+	TestSPID   = "f01228000"
+)
+
+var MockHeyfilHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/sp" {
+		http.Error(w, "nope, bad path", http.StatusBadRequest)
+		return
+	}
+	if r.URL.RawQuery != "peerid="+TestPeerID {
+		http.Error(w, "nope, bad query", http.StatusBadRequest)
+		return
+	}
+	fmt.Fprintf(w, `["%s"]\n`, TestSPID)
+})

--- a/testdata/aggregategood.json
+++ b/testdata/aggregategood.json
@@ -1,0 +1,95 @@
+    {
+        "events": [
+            {
+                "bandwidth": 200000,
+                "bytesTransferred": 10000,
+                "endTime": "1970-01-01T10:00:00.09+10:00",
+                "indexerCandidatesFiltered": 3,
+                "indexerCandidatesReceived": 5,
+                "instanceId": "test-instance",
+                "protocolSucceeded": "transport-bitswap",
+                "protocolsAllowed": [
+                    "transport-graphsync-filecoinv1",
+                    "transport-bitswap"
+                ],
+                "protocolsAttempted": [
+                    "transport-graphsync-filecoinv1",
+                    "transport-bitswap"
+                ],
+                "retrievalAttempts": {
+                    "12D3KooWEqwTBN3GE4vT6DWZiKpq24UtSBmhhwM73vg7SfTjYWaF": {
+                        "protocol": "transport-graphsync-filecoinv1",
+                        "timeToFirstByte": "50ms"
+                    },
+                    "12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqu": {
+                        "error": "failed to dial",
+                        "protocol": "transport-graphsync-filecoinv1"
+                    },
+                    "Bitswap": {
+                        "protocol": "transport-bitswap",
+                        "timeToFirstByte": "20ms"
+                    }
+                },
+                "retrievalId": "c8490080-b86f-4306-a657-a0b88ac43832",
+                "rootCid": "QmTTA2daxGqo5denp6SwLzzkLJm3fuisYEi9CoWsuHpzfb",
+                "startTime": "1970-01-01T10:00:00+10:00",
+                "storageProviderId": "Bitswap",
+                "success": true,
+                "timeToFirstByte": "40ms",
+                "timeToFirstIndexerResult": "10ms",
+                "urlPath": "/applesauce"
+            },
+            {
+                "endTime": "1970-01-01T10:00:00+10:00",
+                "indexerCandidatesFiltered": 0,
+                "indexerCandidatesReceived": 0,
+                "instanceId": "test-instance",
+                "retrievalId": "5f06fd27-36db-47f8-a0f5-ef20bd0ae4b5",
+                "rootCid": "QmTTA2daxGqo5denp6SwLzzkLJm3fuisYEi9CoWsuHpzfb",
+                "startTime": "1970-01-01T10:00:00+10:00",
+                "success": false,
+                "urlPath": "/applesauce"
+            },
+            {
+                "bandwidth": 300000,
+                "bytesTransferred": 20000,
+                "endTime": "1970-01-01T10:00:00.18+10:00",
+                "indexerCandidatesFiltered": 6,
+                "indexerCandidatesReceived": 10,
+                "instanceId": "test-instance",
+                "protocolSucceeded": "transport-ipfs-gateway-http",
+                "protocolsAllowed": [
+                    "transport-ipfs-gateway-http",
+                    "transport-graphsync-filecoinv1",
+                    "transport-bitswap"
+                ],
+                "protocolsAttempted": [
+                    "transport-ipfs-gateway-http",
+                    "transport-graphsync-filecoinv1",
+                    "transport-bitswap"
+                ],
+                "retrievalAttempts": {
+                    "12D3KooWDGBkHBZye7rN6Pz9ihEZrHnggoVRQh6eEtKP4z1K4KeE": {
+                        "protocol": "transport-ipfs-gateway-http",
+                        "timeToFirstByte": "100ms"
+                    },
+                    "12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqu": {
+                        "error": "failed to dial",
+                        "protocol": "transport-graphsync-filecoinv1"
+                    },
+                    "Bitswap": {
+                        "protocol": "transport-bitswap",
+                        "timeToFirstByte": "200ms"
+                    }
+                },
+                "retrievalId": "c8490080-b86f-4306-a657-a0b88ac43834",
+                "rootCid": "QmTTA2daxGqo5denp6SwLzzkLJm3fuisYEi9CoWsuHpzfb",
+                "startTime": "1970-01-01T10:00:00.02+10:00",
+                "storageProviderId": "12D3KooWDGBkHBZye7rN6Pz9ihEZrHnggoVRQh6eEtKP4z1K4KeE",
+                "success": true,
+                "timeToFirstByte": "80ms",
+                "timeToFirstIndexerResult": "20ms",
+                "urlPath": "/applesauce"
+            }
+        ]
+    }


### PR DESCRIPTION
Big changeset here but it's mostly about adding tests and testability, with some very minor fixes. The main change is relatively small (see middle commit), in plumbing through the Filecoin SP ID through to the prometheus metrics as an attribute `"fil_sp_id"` (on metrics `request_with_success`, and `request_with_{graphsync,http}_success`), which is an empty string if it's not found by heyfil. I'm making the assumption (without actually doing this yet) that we can filter on `fil_sp_id!=''` in Grafana to differentiate successes from filecoin. I've left alone the non-aggregate, /v1/, reports here, I'm assuming we're going to be deleting that soon because it's not in use.

In making this change, we now do the peerid->filecoin_spid lookup on each aggregate report rather than inside the mongo branch which only does a % of the reports. But, the LRU should help us out there and not make that have too large an impact.

This doesn't touch the postgres database, but we have the option of extending that table and putting this value into a column.