### PR TITLE
feat: add bytes transferred per event

### DIFF
--- a/eventrecorder/event.go
+++ b/eventrecorder/event.go
@@ -121,9 +121,10 @@ func (e EventBatch) Validate() error {
 }
 
 type RetrievalAttempt struct {
-	Error           string `json:"error,omitempty"`
-	TimeToFirstByte string `json:"timeToFirstByte,omitempty"`
-	Protocol        string `json:"protocol,omitempty"`
+	Error            string `json:"error,omitempty"`
+	TimeToFirstByte  string `json:"timeToFirstByte,omitempty"`
+	BytesTransferred uint64 `json:"bytesTransferred,omitempty"`
+	Protocol         string `json:"protocol,omitempty"`
 }
 
 type AggregateEvent struct {

--- a/eventrecorder/recorder.go
+++ b/eventrecorder/recorder.go
@@ -227,25 +227,28 @@ func (r *EventRecorder) RecordAggregateEvents(ctx context.Context, events []Aggr
 				lk.Lock()
 				defer lk.Unlock()
 				attempts[storageProviderID] = metrics.Attempt{
-					FilSPID:         filSPID,
-					Error:           retrievalAttempt.Error,
-					Protocol:        retrievalAttempt.Protocol,
-					TimeToFirstByte: timeToFirstByte,
+					FilSPID:          filSPID,
+					Error:            retrievalAttempt.Error,
+					Protocol:         retrievalAttempt.Protocol,
+					TimeToFirstByte:  timeToFirstByte,
+					BytesTransferred: retrievalAttempt.BytesTransferred,
 				}
 				query := `
 			  INSERT INTO retrieval_attempts(
 				  retrieval_id,
 				  storage_provider_id,
 				  time_to_first_byte,
+				  bytes_transferred,
 				  error,
 				  protocol
 			  )
-			  VALUES ($1, $2, $3, $4, $5)
+			  VALUES ($1, $2, $3, $4, $5, $6)
 			  `
 				batchRetrievalAttempts.Queue(query,
 					event.RetrievalID,
 					storageProviderID,
 					timeToFirstByte,
+					retrievalAttempt.BytesTransferred,
 					retrievalAttempt.Error,
 					retrievalAttempt.Protocol,
 				).Exec(func(ct pgconn.CommandTag) error {

--- a/eventrecorder/recorder_test.go
+++ b/eventrecorder/recorder_test.go
@@ -38,18 +38,20 @@ var expectedEvents = []ae{
 		protocolSucceeded:        "transport-bitswap",
 		attempts: map[string]metrics.Attempt{
 			"12D3KooWEqwTBN3GE4vT6DWZiKpq24UtSBmhhwM73vg7SfTjYWaF": {
-				Error:           "",
-				Protocol:        "transport-graphsync-filecoinv1",
-				TimeToFirstByte: 50 * time.Millisecond,
+				Error:            "",
+				Protocol:         "transport-graphsync-filecoinv1",
+				TimeToFirstByte:  50 * time.Millisecond,
+				BytesTransferred: 10001,
 			},
 			"12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqu": {
 				Error:    "failed to dial",
 				Protocol: "transport-graphsync-filecoinv1",
 			},
 			"Bitswap": {
-				Error:           "",
-				Protocol:        "transport-bitswap",
-				TimeToFirstByte: 20 * time.Millisecond,
+				Error:            "",
+				Protocol:         "transport-bitswap",
+				TimeToFirstByte:  20 * time.Millisecond,
+				BytesTransferred: 20002,
 			},
 		},
 	},
@@ -85,18 +87,20 @@ var expectedEvents = []ae{
 		protocolSucceeded:        "transport-ipfs-gateway-http",
 		attempts: map[string]metrics.Attempt{
 			"12D3KooWDGBkHBZye7rN6Pz9ihEZrHnggoVRQh6eEtKP4z1K4KeE": {
-				Error:           "",
-				Protocol:        "transport-ipfs-gateway-http",
-				TimeToFirstByte: 100 * time.Millisecond,
+				Error:            "",
+				Protocol:         "transport-ipfs-gateway-http",
+				TimeToFirstByte:  100 * time.Millisecond,
+				BytesTransferred: 10001,
 			},
 			"12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqu": {
 				Error:    "failed to dial",
 				Protocol: "transport-graphsync-filecoinv1",
 			},
 			"Bitswap": {
-				Error:           "",
-				Protocol:        "transport-bitswap",
-				TimeToFirstByte: 200 * time.Millisecond,
+				Error:            "",
+				Protocol:         "transport-bitswap",
+				TimeToFirstByte:  200 * time.Millisecond,
+				BytesTransferred: 20002,
 			},
 		},
 	},
@@ -154,6 +158,7 @@ func TestRecorderMetrics(t *testing.T) {
 			req.Equal(aa.Error, mm.aggregatedEvents[ii].attempts[k].Error)
 			req.Equal(aa.Protocol, mm.aggregatedEvents[ii].attempts[k].Protocol)
 			req.Equal(aa.TimeToFirstByte, mm.aggregatedEvents[ii].attempts[k].TimeToFirstByte)
+			req.Equal(aa.BytesTransferred, mm.aggregatedEvents[ii].attempts[k].BytesTransferred)
 		}
 	}
 }

--- a/metrics/events.go
+++ b/metrics/events.go
@@ -147,10 +147,11 @@ func (m *Metrics) HandleSuccessEvent(ctx context.Context, id types.RetrievalID, 
 }
 
 type Attempt struct {
-	FilSPID         string
-	Error           string
-	Protocol        string
-	TimeToFirstByte time.Duration
+	FilSPID          string
+	Error            string
+	Protocol         string
+	TimeToFirstByte  time.Duration
+	BytesTransferred uint64
 }
 
 func (m *Metrics) HandleAggregatedEvent(ctx context.Context,
@@ -175,7 +176,11 @@ func (m *Metrics) HandleAggregatedEvent(ctx context.Context,
 		protocolAttempted := protocolFromMulticodecString(attempt.Protocol)
 		switch protocolAttempted {
 		case ProtocolBitswap:
-			m.requestWithBitswapAttempt.Add(ctx, 1, attribute.String("protocol", "bitswap"))
+			if storageProviderID != "Bitswap" {
+				m.requestWithGraphSyncAttempt.Add(ctx, 1, attribute.String("protocol", "bitswap"), attribute.String("sp_id", storageProviderID), attribute.String("fil_sp_id", attempt.FilSPID))
+			} else {
+				m.requestWithBitswapAttempt.Add(ctx, 1, attribute.String("protocol", "bitswap"))
+			}
 		case ProtocolGraphsync:
 			m.requestWithGraphSyncAttempt.Add(ctx, 1, attribute.String("protocol", "graphsync"), attribute.String("sp_id", storageProviderID), attribute.String("fil_sp_id", attempt.FilSPID))
 		case ProtocolHttp:

--- a/schema.sql
+++ b/schema.sql
@@ -16,6 +16,7 @@ create table if not exists aggregate_retrieval_events(
   url_path text,
   instance_id character varying(64) not null,
   storage_provider_id character varying(256),
+  filecoin_storage_provider_id character varying(16),
   time_to_first_byte bigint,
   bandwidth_bytes_sec bigint,
   bytes_transferred bigint,
@@ -33,6 +34,7 @@ create table if not exists aggregate_retrieval_events(
 create table if not exists retrieval_attempts(
   retrieval_id uuid not null,
   storage_provider_id character varying(256),
+  filecoin_storage_provider_id character varying(16),
   time_to_first_byte bigint,
   error text,
   protocol character varying(256),

--- a/schema.sql
+++ b/schema.sql
@@ -36,5 +36,6 @@ create table if not exists retrieval_attempts(
   time_to_first_byte bigint,
   error text,
   protocol character varying(256),
+  bytes_transferred bigint,
   FOREIGN KEY (retrieval_id) REFERENCES aggregate_retrieval_events (retrieval_id)
 );

--- a/testdata/aggregategood.json
+++ b/testdata/aggregategood.json
@@ -19,7 +19,8 @@
                 "retrievalAttempts": {
                     "12D3KooWEqwTBN3GE4vT6DWZiKpq24UtSBmhhwM73vg7SfTjYWaF": {
                         "protocol": "transport-graphsync-filecoinv1",
-                        "timeToFirstByte": "50ms"
+                        "timeToFirstByte": "50ms",
+                        "bytesTransferred": 10001
                     },
                     "12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqu": {
                         "error": "failed to dial",
@@ -27,7 +28,8 @@
                     },
                     "Bitswap": {
                         "protocol": "transport-bitswap",
-                        "timeToFirstByte": "20ms"
+                        "timeToFirstByte": "20ms",
+                        "bytesTransferred": 20002
                     }
                 },
                 "retrievalId": "c8490080-b86f-4306-a657-a0b88ac43832",
@@ -71,7 +73,8 @@
                 "retrievalAttempts": {
                     "12D3KooWDGBkHBZye7rN6Pz9ihEZrHnggoVRQh6eEtKP4z1K4KeE": {
                         "protocol": "transport-ipfs-gateway-http",
-                        "timeToFirstByte": "100ms"
+                        "timeToFirstByte": "100ms",
+                        "bytesTransferred": 10001
                     },
                     "12D3KooWHHzSeKaY8xuZVzkLbKFfvNgPPeKhFBGrMbNzbm5akpqu": {
                         "error": "failed to dial",
@@ -79,7 +82,8 @@
                     },
                     "Bitswap": {
                         "protocol": "transport-bitswap",
-                        "timeToFirstByte": "200ms"
+                        "timeToFirstByte": "200ms",
+                        "bytesTransferred": 20002
                     }
                 },
                 "retrievalId": "c8490080-b86f-4306-a657-a0b88ac43834",


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/lassie/pull/345

Needs this done on the current DB to bring it up to the schema in here:

```sql
ALTER TABLE retrieval_attempts ADD COLUMN bytes_transferred bigint;
```

As is, with https://github.com/filecoin-project/lassie/pull/345 deployed, this would add an attempt per **peer** that's involved in a bitswap retrieval, it'll also tag those that are Filecoin SPs in the prometheus metrics. I don't think we currently have insight into how many peers are involved in a retrieval, on average, so I'm not sure how much extra chatter this is going to add to the database.

It won't do anything with the number of bytes transferred per provider other than slot that into the database. We may need to reflect further on the dashboard regarding how/if we want to include that somehow (e.g. some kind of ranking per bytes transferred? maybe a Filecoin SP was involved in a bitswap retrieval but contributed a single block to a 100 block retrieval, do we care?).