### PR TITLE
feat: add Filecoin SP ID to events database

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -16,6 +16,7 @@ create table if not exists aggregate_retrieval_events(
   url_path text,
   instance_id character varying(64) not null,
   storage_provider_id character varying(256),
+  filecoin_storage_provider_id character varying(16),
   time_to_first_byte bigint,
   bandwidth_bytes_sec bigint,
   bytes_transferred bigint,
@@ -33,6 +34,7 @@ create table if not exists aggregate_retrieval_events(
 create table if not exists retrieval_attempts(
   retrieval_id uuid not null,
   storage_provider_id character varying(256),
+  filecoin_storage_provider_id character varying(16),
   time_to_first_byte bigint,
   error text,
   protocol character varying(256),


### PR DESCRIPTION
This adds a new column to both `aggregate_retrieval_events` and `retrieval_attempts` named `filecoin_storage_provider_id` that may have a Filecoin SP ID or an empty string. Useful for SQL queries; we currently have this in prometheus only.

Requires this on the live DB:

```sql
ALTER TABLE aggregate_retrieval_events ADD COLUMN filecoin_storage_provider_id character varying(16);
ALTER TABLE retrieval_attempts ADD COLUMN filecoin_storage_provider_id character varying(16);
```